### PR TITLE
Remove auto-applied label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: "Bug report"
 description: "Use this template if you're running into issues with Windows, macOS, or Linux (native package) version."
-labels: bug
 body:
   - type: checkboxes
     id: unique

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: "Feature request"
 description: "Use this form to suggest a feature."
-labels: enhancement
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
We use label as manual indication that our team is
asked all necessaries question and correctly labeled issue, so
we mark them manually in 100% cases