### PR TITLE
Update winget installers-regex to include arm64 installer

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,6 +10,6 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: ONLYOFFICE.DesktopEditors
-          installers-regex: '(x86|x64)\.(exe|msi)$'
+          installers-regex: '(x86|x64|arm64)\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
 


### PR DESCRIPTION
Added new installer which was missing in winget here: https://github.com/microsoft/winget-pkgs/pull/319911